### PR TITLE
add fix for self._heap is Nonetype error

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -265,6 +265,8 @@ class Scheduler(object):
         self._heap = []
         for entry in values(self.schedule):
             is_due, next_call_delay = entry.is_due()
+            if self._heap is None:
+                self._heap = []
             self._heap.append(event_t(
                 self._when(
                     entry,


### PR DESCRIPTION
**Summary:** This PR adds a fix for the celery-beat exception occurring in *celery/beat.py* where the `'NoneType' object has no attribute 'append'`. This error restarts the beat container that causes scheduled tasks to be missed if there are tasks executing while beat is restarting.

This exception was caused by the `self._heap` instance variable being set to `None` right before `self._heap.append` is called. The offending code came from *django-celery-beat/schedulers.py* which sets the heap to `None` in order to handle initial reads and updates of the schedules.

Instead of making any changes to versioning or reverting to older commits that could introduce new bugs, adding a check that sets the heap to an empty list when `None` seemed like the best way to patch this issue. 